### PR TITLE
include acyclic method

### DIFF
--- a/sknetwork/utils/check.py
+++ b/sknetwork/utils/check.py
@@ -317,3 +317,12 @@ def check_n_components(n_components, n_min) -> int:
         return n_min
     else:
         return n_components
+
+
+def is_acyclic(entry) -> bool:
+    """Boolean indicating whether the adjacency matrix is acyclic."""
+    for _ in range(len(entry)):
+        entry = entry.dot(entry)
+        if np.sum(entry) == 0:
+            return True
+    return False

--- a/sknetwork/utils/tests/test_check.py
+++ b/sknetwork/utils/tests/test_check.py
@@ -169,3 +169,27 @@ class TestChecks(unittest.TestCase):
         self.assertEqual(5, check_n_components(5, 10))
         with self.assertWarns(Warning):
             self.assertEqual(2, check_n_components(5, 2))
+
+    def test_acyclic(self):
+
+        # cyclic graph
+        m = np.array([
+            [0,1,0,0,0,0], 
+            [0,0,1,1,0,0], 
+            [0,0,0,0,0,0], 
+            [0,0,0,0,1,0], 
+            [0,0,0,0,0,1], 
+            [0,0,1,1,0,0]])
+        
+        self.assertFalse(is_acyclic(m))
+
+        # an acyclic graph
+        m = np.array([
+            [0, 1, 0, 0, 0, 0], 
+            [0, 0, 1, 1, 0, 0], 
+            [0, 0, 0, 0, 0, 0], 
+            [0, 0, 0, 0, 1, 1], 
+            [0, 0, 0, 0, 0, 1], 
+            [0, 0, 1, 0, 0, 0]])
+
+        self.assertTrue(is_acyclic(m))


### PR DESCRIPTION
included a method to determine if an adjacency matrix is acyclic. it looks like this:
```python
from sknetwork.utils.check import is_acyclic
is_acyclic(M)  # returns True if M is an acyclic matrix 
```

although most libraries (eg networkx) [leave it up to the user to check for acyclic-ness](https://networkx.github.io/documentation/stable/reference/algorithms/dag.html), it is a common task so i think scikit-network should include it.

