### PR TITLE
implement betweenness

### DIFF
--- a/sknetwork/utils/betweenness.py
+++ b/sknetwork/utils/betweenness.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+@author: vincent tang <vin.tang@gmail.com>
+"""
+from typing import Union
+
+import numpy as np
+from scipy import sparse
+from scipy.sparse.csgraph import shortest_path
+
+
+def _get_path(Pr, i, j):
+    path = [j]
+    k = j
+    while Pr[i, k] != -9999:
+        path.append(Pr[i, k])
+        k = Pr[i, k]
+    return path[::-1]
+
+
+def betweenness_centrality(entry: Union[sparse.csr_matrix, np.ndarray]) -> dict:
+    """Computes betweenness for adjacency matrix."""
+    
+    D, Pr = shortest_path(entry, directed=True, method='FW', return_predecessors=True)
+    n_vertex = len(entry)    
+
+    # find shortest path for each pair source/target vertices
+    betweenness = {}
+    for s in range(n_vertex):
+        for t in range(n_vertex):
+            path = _get_path(Pr, s, t)
+            
+            # we're interested only if there is at least one vertex between source and target vertices
+            if len(path) > 2:  
+                for v in path[1:-1]:
+                    if v not in betweenness.keys():
+                        betweenness[v] = 1
+                    else:
+                        betweenness[v] += 1
+    return betweenness

--- a/sknetwork/utils/tests/test_betweenness.py
+++ b/sknetwork/utils/tests/test_betweenness.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""tests for check.py"""
+
+import unittest
+import numpy as np
+
+from sknetwork.utils.betweenness import betweenness_centrality
+
+
+class TestChecks(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_betweenness(self):
+        # example from https://neo4j.com/docs/graph-algorithms/current/labs-algorithms/betweenness-centrality/
+        M = np.array([
+            [0,1,1,1,0,0], 
+            [0,0,0,0,0,0], 
+            [0,0,0,0,0,1], 
+            [0,0,0,0,0,0], 
+            [1,0,0,0,0,0], 
+            [0,0,0,0,0,0]])
+
+        ans = {2: 2, 0: 4}
+        res = betweenness_centrality(M)
+        self.assertDictEqual(res, ans)


### PR DESCRIPTION
# [implement betweenness](https://github.com/sknetwork-team/scikit-network/projects/28)

implemented betweenness centrality using [scipy's floyd warshall](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csgraph.shortest_path.html) algorithm. method returns a python dict where key represents vertex index and value represents its betweenness score.

```python
M = np.array([[0,1,1,1,0,0], 
              [0,0,0,0,0,0], 
              [0,0,0,0,0,1], 
              [0,0,0,0,0,0], 
              [1,0,0,0,0,0], 
              [0,0,0,0,0,0]])

betweenness_centrality(M)  # returns {2: 2, 0: 4}
```