### PR TITLE
Fix #450: support 64-bit indices in Louvain

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -31,4 +31,4 @@ Contributors
 * Pierre Pébereau
 * Armand Boschin
 * Tiphaine Viard
-
+* Flávio Juvenal <flavio@vinta.com.br>

--- a/sknetwork/clustering/louvain.py
+++ b/sknetwork/clustering/louvain.py
@@ -130,8 +130,8 @@ class Louvain(BaseClustering, VerboseMixin):
 
         self_loops = adjacency.diagonal().astype(np.float32)
 
-        indptr: np.ndarray = adjacency.indptr.astype(np.int32)
-        indices: np.ndarray = adjacency.indices.astype(np.int32)
+        indptr: np.ndarray = adjacency.indptr
+        indices: np.ndarray = adjacency.indices
         data: np.ndarray = adjacency.data.astype(np.float32)
 
         return fit_core(self.resolution, self.tol, node_probs_ou, node_probs_in, self_loops, data, indices, indptr)
@@ -188,7 +188,7 @@ class Louvain(BaseClustering, VerboseMixin):
         else:
             raise ValueError('Unknown modularity function.')
 
-        nodes = np.arange(n, dtype=np.int32)
+        nodes = np.arange(n)
         if self.shuffle_nodes:
             nodes = self.random_state.permutation(nodes)
             adjacency = adjacency[nodes, :].tocsc()[:, nodes].tocsr()

--- a/sknetwork/clustering/louvain_core.pyx
+++ b/sknetwork/clustering/louvain_core.pyx
@@ -6,11 +6,14 @@ from libcpp.set cimport set
 from libcpp.vector cimport vector
 cimport cython
 
+ctypedef fused int_or_long:
+    int
+    long
 
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def fit_core(float resolution, float tol, float[:] ou_node_probs, float[:] in_node_probs, float[:] self_loops,
-             float[:] data, int[:] indices, int[:] indptr):  # pragma: no cover
+             float[:] data, int_or_long[:] indices, int_or_long[:] indptr):  # pragma: no cover
     """Fit the clusters to the objective function.
 
     Parameters
@@ -39,16 +42,16 @@ def fit_core(float resolution, float tol, float[:] ou_node_probs, float[:] in_no
     total_increase :
         Score of the clustering (total increase in modularity).
     """
-    cdef int n = indptr.shape[0] - 1
-    cdef int increase = 1
-    cdef int cluster
-    cdef int cluster_best
-    cdef int cluster_node
-    cdef int i
-    cdef int j
-    cdef int j1
-    cdef int j2
-    cdef int label
+    cdef int_or_long n = indptr.shape[0] - 1
+    cdef int_or_long increase = 1
+    cdef int_or_long cluster
+    cdef int_or_long cluster_best
+    cdef int_or_long cluster_node
+    cdef int_or_long i
+    cdef int_or_long j
+    cdef int_or_long j1
+    cdef int_or_long j2
+    cdef int_or_long label
 
     cdef float increase_total = 0
     cdef float increase_pass
@@ -61,11 +64,11 @@ def fit_core(float resolution, float tol, float[:] ou_node_probs, float[:] in_no
     cdef float ratio_in
     cdef float ratio_ou
 
-    cdef vector[int] labels
+    cdef vector[int_or_long] labels
     cdef vector[float] neighbor_clusters_weights
     cdef vector[float] ou_clusters_weights
     cdef vector[float] in_clusters_weights
-    cdef set[int] unique_clusters = ()
+    cdef set[int_or_long] unique_clusters = ()
 
     for i in range(n):
         labels.push_back(i)

--- a/sknetwork/clustering/tests/test_louvain.py
+++ b/sknetwork/clustering/tests/test_louvain.py
@@ -67,6 +67,39 @@ class TestLouvainClustering(unittest.TestCase):
         # aggregate graph
         Louvain(n_aggregations=1, sort_clusters=False).fit(adjacency)
 
+    def test_options_with_64_bit(self):
+        adjacency = karate_club()
+        # force 64-bit index
+        adjacency.indices = adjacency.indices.astype(np.int64)
+        adjacency.indptr = adjacency.indptr.astype(np.int64)
+
+        # resolution
+        louvain = Louvain(resolution=2)
+        labels = louvain.fit_transform(adjacency)
+        self.assertEqual(len(set(labels)), 7)
+
+        # tolerance
+        louvain = Louvain(resolution=2, tol_aggregation=0.1)
+        labels = louvain.fit_transform(adjacency)
+        self.assertEqual(len(set(labels)), 12)
+
+        # shuffling
+        louvain = Louvain(resolution=2, shuffle_nodes=True, random_state=42)
+        labels = louvain.fit_transform(adjacency)
+        self.assertEqual(len(set(labels)), 9)
+
+        # aggregate graph
+        louvain = Louvain(return_aggregate=True)
+        labels = louvain.fit_transform(adjacency)
+        n_labels = len(set(labels))
+        self.assertEqual(louvain.adjacency_.shape, (n_labels, n_labels))
+
+        # aggregate graph
+        Louvain(n_aggregations=1, sort_clusters=False).fit(adjacency)
+
+        # check if labels are 64-bit
+        self.assertEqual(labels.dtype, np.int64)
+
     def test_invalid(self):
         adjacency = karate_club()
         louvain = Louvain(modularity='toto')


### PR DESCRIPTION
### Modifications:
* Closes " 64-bit Louvain? Support more than 2147483647 edges #450"

### Impacted submodules:
 * sknetwork.clustering.louvain

### This pull request:
- [ ] **does not decrease code coverage**
- [ ] **passes the tests**
- [ ] **is documented** and **the documentation build passes**
- [ ] **has PEP8-compliant code** and **explicit variable naming**
- [ ] **has a tutorial** (facultative but recommended)

*Any doubts about some technicalities? Do not hesitate to look at the [dedicated Wiki](https://github.com/sknetwork-team/scikit-network/wiki/Contributing-guide).*
