### PR TITLE
MAINT: consistent numpy versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,8 @@ from distutils.command.build_ext import build_ext
 import os
 from glob import glob
 
-dist.Distribution().fetch_build_eggs(['Cython', 'numpy==1.20.0'])
+numpy_min_version = '1.20.2'
+dist.Distribution().fetch_build_eggs(['Cython', f'numpy>={numpy_min_version}'])
 
 import numpy
 
@@ -21,7 +22,7 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = ['numpy>=1.20.2', 'scipy>=1.6.2']
+requirements = [f'numpy>={numpy_min_version}', 'scipy>=1.6.2']
 
 setup_requirements = ['pytest-runner']
 


### PR DESCRIPTION
### Modifications:
I have numpy 1.21 installed on my machine and I can't build the module from source without downgrading numpy to 1.20.0.
Here I have added a variable `numpy_min_version` which sets a consistent numpy version in `setup.py`.

### Impacted submodules:
setup.py

### This pull request:
(your PR must match these criteria before review)
- [X ] **targets the `develop` branch**