### PR TITLE
only use cython linetrace and CYTHON_TRACE_NOGIL on tests

### DIFF
--- a/.github/workflows/ci_checks.yml
+++ b/.github/workflows/ci_checks.yml
@@ -8,6 +8,8 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    env:
+      WITH_CYTHON_PROFILE: ON
     strategy:
       fail-fast: false
       matrix:

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,12 @@ if os.environ.get('SKNETWORK_DISABLE_CYTHONIZE') is None:
 else:
     HAVE_CYTHON = False
 
+if os.environ.get('WITH_CYTHON_PROFILE') is not None:
+    ext_define_macros = [('CYTHON_TRACE_NOGIL', '1')]
+    compiler_directives = {'linetrace': True}
+else:
+    ext_define_macros = []
+    compiler_directives = {}
 
 if HAVE_CYTHON:
     from Cython.Build import cythonize
@@ -110,7 +116,10 @@ if HAVE_CYTHON:
 
         ext_modules += cythonize(Extension(name=mod_name, sources=[pyx_path], include_dirs=[numpy.get_include()],
                                            extra_compile_args=EXTRA_COMPILE_ARGS,
-                                           extra_link_args=EXTRA_LINK_ARGS), annotate=True)
+                                           extra_link_args=EXTRA_LINK_ARGS,
+                                           define_macros=ext_define_macros),
+                                 annotate=True,
+                                 compiler_directives=compiler_directives)
 else:
     ext_modules = [Extension(modules[index], [c_paths[index]], include_dirs=[numpy.get_include()])
                    for index in range(len(modules))]

--- a/sknetwork/classification/vote.pyx
+++ b/sknetwork/classification/vote.pyx
@@ -1,7 +1,5 @@
 # distutils: language = c++
 # cython: language_level=3
-# cython: linetrace=True
-# distutils: define_macros=CYTHON_TRACE_NOGIL=1
 """
 Created on April, 2020
 @author: Nathan de Lara <nathan.delara@polytechnique.org>

--- a/sknetwork/clustering/louvain_core.pyx
+++ b/sknetwork/clustering/louvain_core.pyx
@@ -1,7 +1,5 @@
 # distutils: language = c++
 # cython: language_level=3
-# cython: linetrace=True
-# distutils: define_macros=CYTHON_TRACE_NOGIL=1
 from libcpp.set cimport set
 from libcpp.vector cimport vector
 cimport cython

--- a/sknetwork/hierarchy/paris.pyx
+++ b/sknetwork/hierarchy/paris.pyx
@@ -1,7 +1,5 @@
 # distutils: language = c++
 # cython: language_level=3
-# cython: linetrace=True
-# distutils: define_macros=CYTHON_TRACE_NOGIL=1
 """
 Created on March 2019
 @author: Thomas Bonald <bonald@enst.fr>

--- a/sknetwork/linalg/diteration.pyx
+++ b/sknetwork/linalg/diteration.pyx
@@ -1,7 +1,5 @@
 # distutils: language = c++
 # cython: language_level=3
-# cython: linetrace=True
-# distutils: define_macros=CYTHON_TRACE_NOGIL=1
 """
 Created on Apr 2020
 @author: Nathan de Lara <nathan.delara@polytechnique.org>

--- a/sknetwork/linalg/push.pyx
+++ b/sknetwork/linalg/push.pyx
@@ -1,7 +1,5 @@
 # distutils: language = c++
 # cython: language_level=3
-# cython: linetrace=True
-# distutils: define_macros=CYTHON_TRACE_NOGIL=1
 """
 Created on Mars 2021
 @author: Wenzhuo Zhao <wenzhuo.zhao@etu.sorbonne-universite.fr>

--- a/sknetwork/ranking/betweenness.pyx
+++ b/sknetwork/ranking/betweenness.pyx
@@ -1,7 +1,5 @@
 # distutils: language = c++
 # cython: language_level=3
-# cython: linetrace=True
-# distutils: define_macros=CYTHON_TRACE_NOGIL=1
 """
 Created on September 17 2020
 @author: Tiphaine Viard <tiphaine.viard@telecom-paris.fr>

--- a/sknetwork/topology/dag_core.pyx
+++ b/sknetwork/topology/dag_core.pyx
@@ -1,7 +1,5 @@
 # distutils: language = c++
 # cython: language_level=3
-# cython: linetrace=True
-# distutils: define_macros=CYTHON_TRACE_NOGIL=1
 """
 Created on Jun 3, 2020
 @author: Nathan de Lara <nathan.delara@polytechnique.org>

--- a/sknetwork/topology/kcliques.pyx
+++ b/sknetwork/topology/kcliques.pyx
@@ -1,7 +1,5 @@
 # distutils: language = c++
 # cython: language_level=3
-# cython: linetrace=True
-# distutils: define_macros=CYTHON_TRACE_NOGIL=1
 """
 Created on Jun 3, 2020
 @author: Julien Simonnet <julien.simonnet@etu.upmc.fr>

--- a/sknetwork/topology/kcore.pyx
+++ b/sknetwork/topology/kcore.pyx
@@ -1,7 +1,5 @@
 # distutils: language = c++
 # cython: language_level=3
-# cython: linetrace=True
-# distutils: define_macros=CYTHON_TRACE_NOGIL=1
 """
 Created on Jun 3, 2020
 @author: Julien Simonnet <julien.simonnet@etu.upmc.fr>

--- a/sknetwork/topology/triangles.pyx
+++ b/sknetwork/topology/triangles.pyx
@@ -1,7 +1,5 @@
 # distutils: language = c++
 # cython: language_level=3
-# cython: linetrace=True
-# distutils: define_macros=CYTHON_TRACE_NOGIL=1
 """
 Created on Jun 3, 2020
 @author: Julien Simonnet <julien.simonnet@etu.upmc.fr>

--- a/sknetwork/topology/weisfeiler_lehman_core.pyx
+++ b/sknetwork/topology/weisfeiler_lehman_core.pyx
@@ -1,7 +1,5 @@
 # distutils: language = c++
 # cython: language_level=3
-# cython: linetrace=True
-# distutils: define_macros=CYTHON_TRACE_NOGIL=1
 """
 Created on July 1, 2020
 @author: Pierre Pebereau <pierre.pebereau@telecom-paris.fr>

--- a/sknetwork/utils/minheap.pxd
+++ b/sknetwork/utils/minheap.pxd
@@ -1,7 +1,5 @@
 # distutils: language = c++
 # cython: language_level=3
-# cython: linetrace=True
-# distutils: define_macros=CYTHON_TRACE_NOGIL=1
 """
 Created on Jun 3, 2020
 @author: Julien Simonnet <julien.simonnet@etu.upmc.fr>

--- a/sknetwork/utils/minheap.pyx
+++ b/sknetwork/utils/minheap.pyx
@@ -1,7 +1,5 @@
 # distutils: language = c++
 # cython: language_level=3
-# cython: linetrace=True
-# distutils: define_macros=CYTHON_TRACE_NOGIL=1
 """
 Created on Jun 3, 2020
 @author: Julien Simonnet <julien.simonnet@etu.upmc.fr>


### PR DESCRIPTION
### Modifications:
 * linetrace and CYTHON_TRACE_NOGIL are now setup on setup.py and not in dividual pyx files
 * new env variable detected in setup.py to see if we want cython profiling

### Impacted submodules:
 * all

### This pull request:
- [x] **targets the `develop` branch**
- [x] **does not decrease code coverage**
- [ ] **passes the tests**
- [ ] **is documented** and **the documentation build passes**
- [x] **has PEP8-compliant code** and **explicit variable naming**
- [x] **has a tutorial** (facultative but recommended)

Should fix #498 if it works