### PR TITLE
Using `scikit-base` to have `get_params`, `get_fitted_params` and be composition compatible with, e.g., `scikit-learn` and `sktime`?

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = ['numpy>=1.22.4', 'scipy>=1.7.3']
+requirements = ['numpy>=1.22.4', 'scipy>=1.7.3', 'scikit-base>=0.4.1']
 
 setup_requirements = ['pytest-runner']
 

--- a/sknetwork/utils/base.py
+++ b/sknetwork/utils/base.py
@@ -6,29 +6,11 @@ Created on Jun 28, 2019
 """
 import inspect
 
+from skbase.base import BaseEstimator
 
-class Algorithm:
+
+class Algorithm(BaseEstimator):
     """Base class for all algorithms."""
-    def __repr__(self):
-        # parameters not to display
-        arg_black_list = ['self', 'random_state', 'verbose']
-        output = self.__class__.__name__ + '('
-        signature = inspect.signature(self.__class__.__init__)
-        arguments = [arg.name for arg in signature.parameters.values() if arg.name not in arg_black_list]
-        for p in arguments:
-            try:
-                val = self.__dict__[p]
-            except KeyError:
-                continue
-            if type(val) == str:
-                val = "'" + val + "'"
-            else:
-                val = str(val)
-            output += p + '=' + val + ', '
-        if output[-1] != '(':
-            return output[:-2] + ')'
-        else:
-            return output + ')'
 
     def fit(self, *args, **kwargs):
         """Fit algorithm to data."""


### PR DESCRIPTION
PR and a design proposal in one - would you be open to consider `scikit-base` as the root of your base class tree?

My motivation for contributing this is, I wanted to use `scikit-network` algorithms as components in `sktime` algorithms (in some local playing around), e.g., distance based classification or clustering.

Now, if you don't have `get_params`, `set_params`, the parameters within `scikit-network` cannot be tuned. If you don't have `get_fitted_params`, the fitted parameters cannot be easily read by parameter retrieval interfaces.

Another benefit would be that you could use the testing framework for streamlined API testing (not contained in this PR).

Thoughts? Happy to help with integration - it should mostly be plug & play.

The other option would be doing double inheritance downstream, i.e. inherit from the `scikit-network` estimators in question and `scikit-base` `BaseEstimator`, but that seems more hacky and error prone...

Recent tutorial here:
https://github.com/sktime/sktime-tutorial-pydata-seattle-2023