### PR TITLE
Handle non-uniform behaviour of __builtins__

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ from setuptools import find_packages, setup, Extension
 from sysconfig import get_platform
 from distutils.command.build_ext import build_ext
 import os
+import builtins
 from glob import glob
 
 import numpy
@@ -55,7 +56,6 @@ if platform.startswith("win"):
     EXTRA_COMPILE_ARGS = ['/d2FH4-']
     EXTRA_LINK_ARGS = []
 
-
 class BuildExtSubclass(build_ext):
     def build_options(self):
         for e in self.extensions:
@@ -74,7 +74,7 @@ class BuildExtSubclass(build_ext):
     def finalize_options(self):
         build_ext.finalize_options(self)
         # Prevent numpy from thinking it is still in its setup process:
-        __builtins__.__NUMPY_SETUP__ = False
+        builtins.__NUMPY_SETUP__ = False
         import numpy
         self.include_dirs.append(numpy.get_include())
 


### PR DESCRIPTION
### Modifications:
According to https://docs.python.org/3.9/reference/executionmodel.html:

CPython implementation detail: Users should not touch __builtins__; it is strictly an implementation detail. Users wanting to override values in the builtins namespace should [import](https://docs.python.org/3.9/reference/simple_stmts.html#import) the [builtins](https://docs.python.org/3.9/library/builtins.html#module-builtins) module and modify its attributes appropriately.

The builtins namespace associated with the execution of a code block is actually found by looking up the name __builtins__ in its global namespace; this should be a dictionary or a module (in the latter case the module’s dictionary is used). By default, when in the [__main__](https://docs.python.org/3.9/library/__main__.html#module-__main__) module, __builtins__ is the built-in module [builtins](https://docs.python.org/3.9/library/builtins.html#module-builtins); when in any other module, __builtins__ is an alias for the dictionary of the [builtins](https://docs.python.org/3.9/library/builtins.html#module-builtins) module itself.

------------------------------------------------------------------------------

This fix is needed to package scikit-network in nixpkgs (or at least to be able to remove the workaround)

### Impacted submodules:
None

### This pull request:
(your PR must match these criteria before review)
- [x] **targets the `develop` branch**
- [x] **does not decrease code coverage**
- [x] **passes the tests**
- [x] **is documented** and **the documentation build passes** (does this need documentation?)
- [x] **has PEP8-compliant code** and **explicit variable naming**
- [x] **has a tutorial** (facultative but recommended) (is this applicable for this PR?)
