### PR TITLE
Pin cython no higher than 3.0.12

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
   push:
     tags:
       - "v*"
-  
+
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
@@ -54,7 +54,7 @@ jobs:
 
         - uses: actions/upload-artifact@v4
           with:
-            path: dist/*.tar.gz
+            path: dist/
 
   upload_pypi:
       needs: [ build_wheels, build_sdist ]
@@ -63,13 +63,10 @@ jobs:
         name: pypi
         url: https://pypi.org/p/scikit-network
       permissions:
-        id-token: write 
+        id-token: write
 
       steps:
           - uses: actions/download-artifact@v4
             with:
-              pattern: dist-*
-              merge-multiple: true
-              path: dist
-
+              path: dist/
           - uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,9 +48,9 @@ jobs:
 
         - name: Build sdist
           run: |
-            python -m pip install --upgrade pip
-            python -m pip install -r requirements_dev.txt
-            python setup.py sdist
+                python -m pip install .
+                python -m pip install -r requirements_dev.txt .
+                python -m build
 
         - uses: actions/upload-artifact@v4
           with:

--- a/.github/workflows/wheels_build.yml
+++ b/.github/workflows/wheels_build.yml
@@ -42,13 +42,13 @@ jobs:
               name: Install Python
               with:
                   python-version: '3.9'
-
+                  
           -   name: Build sdist
               run: |
-                python -m pip install --upgrade pip
-                python -m pip install -r requirements_dev.txt
-                python setup.py sdist
+                python -m pip install .
+                python -m pip install -r requirements_dev.txt .
+                python -m build
 
           -   uses: actions/upload-artifact@v4
               with:
-                  path: dist/*.tar.gz
+                  path: dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "setuptools",
     "scipy",
     "pytest-runner",
-    "cython"
+    "cython <= 3.0.12",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
The recent 3.1.0 release broke compiling

```
    | building 'sknetwork.hierarchy.paris' extension
    | creating build/temp.linux-aarch64-cpython-312/sknetwork/hierarchy
    | g++ -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -I/tmp/tmpos1np2up/.venv/lib/python3.12/site-packages/numpy/_core/include -I/tmp/tmpos1np2up/.venv/lib/python3.12/site-packages/numpy/_core/include -I/tmp/tmpos1np2up/.venv/include -I/root/.pyenv/versions/3.12.8/include/python3.12 -I/tmp/tmpos1np2up/.venv/lib/python3.12/site-packages/numpy/_core/include -c ./sknetwork/hierarchy/paris.cpp -o build/temp.linux-aarch64-cpython-312/sknetwork/hierarchy/paris.o -fopenmp
    | In file included from /tmp/tmpos1np2up/.venv/lib/python3.12/site-packages/numpy/_core/include/numpy/ndarraytypes.h:1913,
    |                  from /tmp/tmpos1np2up/.venv/lib/python3.12/site-packages/numpy/_core/include/numpy/ndarrayobject.h:12,
    |                  from /tmp/tmpos1np2up/.venv/lib/python3.12/site-packages/numpy/_core/include/numpy/arrayobject.h:5,
    |                  from ./sknetwork/hierarchy/paris.cpp:1156:
    | /tmp/tmpos1np2up/.venv/lib/python3.12/site-packages/numpy/_core/include/numpy/npy_1_7_deprecated_api.h:17:2: warning: #warning "Using deprecated NumPy API, disable it with " "#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
    |    17 | #warning "Using deprecated NumPy API, disable it with " \
    |       |  ^~~~~~~
    | ./sknetwork/hierarchy/paris.cpp: In function ‘PyObject* __pyx_pf_9sknetwork_9hierarchy_5paris_5Paris_2fit(PyObject*, PyObject*, PyObject*, PyObject*)’:
    | ./sknetwork/hierarchy/paris.cpp:22565:35: error: uninitialized ‘const __pyx_t_20’ [-fpermissive]
    | 22565 |   __pyx_ctuple_int__and_int const __pyx_t_20;
    |       |                                   ^~~~~~~~~~
    | ./sknetwork/hierarchy/paris.cpp:1827:8: note: ‘const __pyx_ctuple_int__and_int’ {aka ‘const struct __pyx_ctuple_int__and_int’} has no user-provided default constructor
    |  1827 | struct __pyx_ctuple_int__and_int {
    |       |        ^~~~~~~~~~~~~~~~~~~~~~~~~
    | ./sknetwork/hierarchy/paris.cpp:1828:7: note: and the implicitly-defined constructor does not initialize ‘int __pyx_ctuple_int__and_int::f0’
    |  1828 |   int f0;
    |       |       ^~
    | ./sknetwork/hierarchy/paris.cpp:23640:23: error: assignment of member ‘__pyx_ctuple_int__and_int::f0’ in read-only object
    | 23640 |         __pyx_t_20.f0 = __pyx_v_node;
    |       |         ~~~~~~~~~~~~~~^~~~~~~~~~~~~~
    | ./sknetwork/hierarchy/paris.cpp:23641:23: error: assignment of member ‘__pyx_ctuple_int__and_int::f1’ in read-only object
    | 23641 |         __pyx_t_20.f1 = __pyx_t_18;
    |       |         ~~~~~~~~~~~~~~^~~~~~~~~~~~
    | error: command '/usr/bin/g++' failed with exit code 1
```

### Modifications:
(new algorithms, added tests or documentation)
 * Item 1
 * Item 2

### Impacted submodules:
(e.g. `sknetwork.topology`)
 * Submodule 1
 * Submodule 2

### This pull request:
(your PR must match these criteria before review)
- [x] **targets the `develop` branch**
- [ ] **does not decrease code coverage**
- [ ] **passes the tests**
- [ ] **is documented** and **the documentation build passes**
- [ ] **has PEP8-compliant code** and **explicit variable naming**
- [ ] **has a tutorial** (facultative but recommended)

*Any doubts about some technicalities? Do not hesitate to look at the [dedicated Wiki](https://github.com/sknetwork-team/scikit-network/wiki/Contributing-guide).*
