### PR TITLE
fix(nn): avoid re-slicing on each iteration

### DIFF
--- a/sknetwork/classification/knn.py
+++ b/sknetwork/classification/knn.py
@@ -65,13 +65,14 @@ class NNClassifier(BaseClassifier):
     def _fit_core(self, embedding, labels, index_train, index_test):
         n_neighbors = check_n_neighbors(self.n_neighbors, len(index_train))
 
-        norms_train = get_norms(embedding[index_train], p=2)
+        embedding_train = embedding[index_train]
+        norms_train = get_norms(embedding_train, p=2)
         neighbors = []
         for i in index_test:
             vector = embedding[i]
             if sparse.issparse(vector):
                 vector = vector.toarray().ravel()
-            distances = norms_train**2 - 2 * embedding[index_train].dot(vector) + np.sum(vector**2)
+            distances = norms_train**2 - 2 * embedding_train.dot(vector) + np.sum(vector**2)
             neighbors += list(index_train[np.argpartition(distances, n_neighbors)[:n_neighbors]])
         labels_neighbor = labels[neighbors]
 

--- a/sknetwork/linkpred/nn.py
+++ b/sknetwork/linkpred/nn.py
@@ -67,6 +67,7 @@ class NNLinker(BaseLinker):
             index_col = np.arange(n)
             n_col = n
         n_neighbors = check_n_neighbors(self.n_neighbors, n_col)
+        embedding_col = embedding[index_col]
 
         row = []
         col = []
@@ -76,7 +77,7 @@ class NNLinker(BaseLinker):
             vector = embedding[i]
             if sparse.issparse(vector):
                 vector = vector.toarray().ravel()
-            similarities = embedding[index_col].dot(vector)
+            similarities = embedding_col.dot(vector)
             nn = np.argpartition(-similarities, n_neighbors)[:n_neighbors]
             mask_nn = np.zeros(n_col, dtype=bool)
             mask_nn[nn] = 1


### PR DESCRIPTION
### Modifications:
 * improve performance of NNLinker and NNClassifier by avoid re-slicing on each iteration

### Impacted submodules:
 * `sknetwork.classification`
 * `sknetwork.linkpred`

### This pull request:
(your PR must match these criteria before review)
- [x] **targets the `develop` branch**
- [x] **does not decrease code coverage**
- [x] **passes the tests**
- [x] **is documented** and **the documentation build passes**
- [x] **has PEP8-compliant code** and **explicit variable naming**
- [x] **has a tutorial** (facultative but recommended)

*Any doubts about some technicalities? Do not hesitate to look at the [dedicated Wiki](https://github.com/sknetwork-team/scikit-network/wiki/Contributing-guide).*
